### PR TITLE
Prevent eye cancer from humans with dark mode preference

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -29,22 +29,20 @@
     padding: 0;
 }
 
-@media (prefers-color-scheme: no-preference) or (prefers-color-scheme: light) {
-    .md-search__form {
-        background-color: white;
-    }
+body:not([data-md-color-scheme="slate"]) .md-search__form {
+    background-color: white;
+}
 
-    .md-search__form:hover {
-        background-color: #ebebeb;
-    }
+body:not([data-md-color-scheme="slate"]) .md-search__form:hover {
+    background-color: #ebebeb;
+}
 
-    .md-search {
-        color: var(--md-default-fg-color);
-    }
+body:not([data-md-color-scheme="slate"]) .md-search {
+    color: var(--md-default-fg-color);
+}
 
-    .md-search__input::placeholder {
-        color: var(--md-default-fg-color);
-    }
+body:not([data-md-color-scheme="slate"]) .md-search__input::placeholder {
+    color: var(--md-default-fg-color);
 }
 
 .md-search__input+.md-search__icon {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -29,24 +29,26 @@
     padding: 0;
 }
 
-.md-search__form {
-    background-color: white;
-}
+@media (prefers-color-scheme: no-preference) or (prefers-color-scheme: light) {
+    .md-search__form {
+        background-color: white;
+    }
 
-.md-search__form:hover {
-    background-color: #ebebeb;
-}
+    .md-search__form:hover {
+        background-color: #ebebeb;
+    }
 
-.md-search {
-    color: var(--md-default-fg-color);
+    .md-search {
+        color: var(--md-default-fg-color);
+    }
+
+    .md-search__input::placeholder {
+        color: var(--md-default-fg-color);
+    }
 }
 
 .md-search__input+.md-search__icon {
     color: inherit;
-}
-
-.md-search__input::placeholder {
-    color: var(--md-default-fg-color);
 }
 
 .col_lg {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ theme:
     - search.suggest
     - search.share
     - content.tabs.link
+    - navigation.tabs
   palette:
   # Palette toggle for light mode
   - media: "(prefers-color-scheme: light)"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,20 @@ theme:
     - search.suggest
     - search.share
     - content.tabs.link
+  palette:
+  # Palette toggle for light mode
+  - media: "(prefers-color-scheme: light)"
+    scheme: default
+    toggle:
+      icon: material/toggle-switch
+      name: Switch to dark mode
+
+  # Palette toggle for dark mode
+  - media: "(prefers-color-scheme: dark)"
+    scheme: slate
+    toggle:
+      icon: material/toggle-switch-off-outline
+      name: Switch to light mode
 
 plugins:
   - search

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,8 @@ theme:
     - search.share
     - content.tabs.link
     - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.top
   palette:
   # Palette toggle for light mode
   - media: "(prefers-color-scheme: light)"


### PR DESCRIPTION
I've also added the feature `navigation.tabs` which adds navigation tabs for all top level entries:

![image](https://user-images.githubusercontent.com/39948112/183257121-8aea4b86-789c-4dd3-a63f-dff87053d579.png)

In my opinion this helps maintaining clarity, especially in larger projects.
If this is not desired, I'll revert the corresponding commit.